### PR TITLE
Refactor crop_vis.py

### DIFF
--- a/motion_tracker/utils/crop_vis.py
+++ b/motion_tracker/utils/crop_vis.py
@@ -1,57 +1,53 @@
 import cv2
 from motion_tracker.utils.image_cropping import Coords, crop_and_resize
 
-def show_img(window_name, img, msec_to_show_for=1500):
-    '''Display an image on the screen for fixed length of milliseconds'''
-
-    cv2.imshow(window_name, img)
-    cv2.waitKey(msec_to_show_for)
-    cv2.destroyWindow(window_name)
-
-
-def add_box(img, box_coords):
-    '''Add a visual blue box corresponding to box_coords'''
-
-    img_copy = img.copy() # Drawing is inplace. Draw on copy to protect orginal
-    cv2.rectangle(img_copy,
-                  pt1=(box_coords.x0, box_coords.y0),
-                  pt2=(box_coords.x1, box_coords.y1),
-                  color=(255, 100, 0),
-                  thickness=2)
-    return img_copy
-
-
 def show_stages_of_random_crop(img, box_coords, output_width=256, output_height=256):
-    '''Display original image, the first training image, and the random crop image'''
+    """Display original image, the first training image, and the random crop image
+
+    Args: 
+    ----
+        img: np.ndarray
+        box_coords: Coords object
+        output_width (optional): int
+        output_height (optional): int
+    """
 
     # Show raw image with bounding box
-    img = add_box(img, box_coords)
-    show_img("Original", img)
+    show_img(img, box_coords.as_array())
 
     # First training image (just resized from raw image)
     img_coords = Coords(0, 0, img.shape[1], img.shape[0])
-    start_img, start_box = crop_and_resize(img, img_coords, box_coords,
+    start_img, start_box_coords = crop_and_resize(img, img_coords, box_coords,
                                            output_width, output_height,
                                            random_crop=False)
-    start_img = add_box(start_img, start_box)
-    show_img("First Training Image", start_img)
+    show_img(start_img, start_box_coords.as_array())
 
     # Second training image
     final_img, final_box_coords = crop_and_resize(img, img_coords, box_coords,
                                                   output_width, output_height)
-    add_box(final_img, box_coords)
-    show_img("Random Crop", final_img)
+    show_img(final_img, final_box_coords.as_array())
 
-def show_single_stage(img, box_coords, title="Happy Dance Image"):
-    """Show an image with its surrounding bounding box
+def show_img(img, box_coords=None, window_name="Happy Dance Image", 
+                      msec_to_show_for=1500):
+    """Show an image, potentially with surrounding bounding boxes
 
     Args:
     ----
         img: np.ndarray
         box_coords: np.ndarray
+        window_name (optional): str
+        msec_to_show_for (optioanl): int
     """
+    
+    img_copy = img.copy() # Any drawing is inplace. Draw on copy to protect original.
+    if box_coords is not None:
+        cv2.rectangle(img_copy,
+                      pt1=(box_coords[0], box_coords[1]),
+                      pt2=(box_coords[2], box_coords[3]),
+                      color=(255, 100, 0),
+                      thickness=2)
 
-    bb_coords = Coords(box_coords[0], box_coords[1],
-                       box_coords[2], box_coords[3])
-    img_w_bb = add_box(img, bb_coords)
-    show_img(title, img_w_bb)
+    cv2.imshow(window_name, img_copy)
+    cv2.waitKey(msec_to_show_for)
+    cv2.destroyWindow(window_name)
+

--- a/motion_tracker/utils/image_generator.py
+++ b/motion_tracker/utils/image_generator.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 import cv2
 from motion_tracker.utils.image_cropping import Coords, crop_and_resize
-from motion_tracker.utils.crop_vis import show_single_stage
+from motion_tracker.utils.crop_vis import show_img
 
 def get_X_y_containers(output_width=256, output_height=256):
     empty_img_accumulator = np.zeros([0, output_width, output_height, 3]).astype('uint8')
@@ -177,6 +177,6 @@ def alov_generator(crops_per_image=10, batch_size=50,
 if __name__ == '__main__':
     my_gen = master_generator(crops_per_image=2, batch_size=50)
     X, y = next(my_gen)
-    for i in range(50):
-        show_single_stage(X['start_img'][i], X['start_box'][i])
-        show_single_stage(X['end_img'][i], y['end_box'][i])
+    for i in range(10):
+        show_img(X['start_img'][i], X['start_box'][i])
+        show_img(X['end_img'][i], y['end_box'][i])


### PR DESCRIPTION
@dansbecker quick update on `crop_vis.py` here. I left the `show_stages_of_random_crop` function because I think that could be worthwhile to have in the future with new image sets, but modified it to call the `show_single_stage`. Still looks maybe a little cluttered with having to select the individual coords from a `Coords` object, but I don't know. Being able to call the `show_single_stage` from the generator file (or another potential file) will mean us passing in numpy arrays of the boxes, which means index access (that's why I didn't refactor that function to just accept a `Coords` object). 
