### PR TITLE
Fix makefile errors/issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ work/.folder_structure_sentinel:
 
 	mkdir -p data/imagenet/bb
 	mkdir data/imagenet/images
+	mkdir -p data/bad_images/imagenet
 
 	mkdir -p data/alov/bb
 
@@ -17,7 +18,7 @@ work/.folder_structure_sentinel:
 # Frames #
 work/.alov_frames_sentinel:
 	curl http://isis-data.science.uva.nl/alov/alov300++_frames.zip -O
-	tar xvf alov300++_frames.zip
+	unzip alov300++_frames.zip
 	mv imagedata++ data/alov/frames
 	rm -rf alov300++_frames.zip imagedata++
 	touch work/.alov_frames_sentinel
@@ -62,10 +63,10 @@ work/imagenet/parsed_bb.csv: work/.imagenet_training_bbox_sentinel \
 	python motion_tracker/data_setup/parse_imagenet_bb.py data/imagenet/bb/ \
 		work/imagenet/parsed_bb.csv
 
-work/imagenet/parsed_bb2.csv: work/.imagenet_training_images_sentinel \
-	work/.imagenet_validation_images_sentinel
-	python motion_tracker/data_setup/parse_imagenet_bb2.py \
-		data/imagenet/images work/imagenet/parsed_bb.csv
+work/imagenet/filtered_bb.csv: work/.imagenet_images_sentinel 
+	python motion_tracker/data_setup/filter_imagenet_bb.py \
+		data/imagenet/images work/imagenet/parsed_bb.csv \
+		work/imagenet/filtered_bb.csv
 
 data/fall11_imagenet_urls.txt:
 	curl http://image-net.org/imagenet_data/urls/imagenet_fall11_urls.tgz \
@@ -74,20 +75,16 @@ data/fall11_imagenet_urls.txt:
 	rm data/imagenet_fall11_urls.tgz
 	mv fall11_urls.txt data/fall11_imagenet_urls.txt
 
-work/.imagenet_training_images_sentinel: motion_tracker/data_setup/download_images.py data/fall11_imagenet_urls.txt
-	python motion_tracker/data_setup/download_images.py "training"
+work/.imagenet_images_sentinel: motion_tracker/data_setup/download_images.py data/fall11_imagenet_urls.txt
+	python motion_tracker/data_setup/download_images.py
 	# Delete images < 3k. They are a thumbnail saying the image wasn't avail. Save list of those files
 	find data/imagenet/images -type f -size -3k | cut -d / -f 4 > work/deleted_files_less_than_3k.txt
 	find data/imagenet/images -type f -size -3k -delete
 	python motion_tracker/data_setup/move_bad_images.py \
-		"data/imagenet/images data/bad_images/imagenet" 
-	touch work/.imagenet_training_images_sentinel
-
-work/.imagenet_validation_images_sentinel: motion_tracker/data_setup/download_images.py data/fall11_imagenet_urls.txt
-	python motion_tracker/data_setup/download_images.py "validation"
-	touch work/.imagenet_validation_images_sentinel
+		data/imagenet/images data/bad_images/imagenet
+	touch work/.imagenet_images_sentinel
 
 imagenet_bb: work/imagenet/parsed_bb.csv
 alov_bb: work/alov/parsed_bb.csv
-data: work/.folder_structure_sentinel imagenet_bb alov_bb
-imagenet_images: work/.imagenet_training_images_sentinel work/.imagenet_validation_images_sentinel work/imagenet/parsed_bb2.csv
+imagenet_images: work/.imagenet_images_sentinel work/imagenet/filtered_bb.csv
+data: work/.folder_structure_sentinel imagenet_bb alov_bb imagenet_images

--- a/motion_tracker/data_setup/download_images.py
+++ b/motion_tracker/data_setup/download_images.py
@@ -62,9 +62,8 @@ class ImageDownloader(object):
 
 
 if __name__ == "__main__":
-    dataset_id = sys.argv[1]
-    bbox_dir = 'data/ILSVRC/bb/' + dataset_id
-    images_dir = 'data/ILSVRC/images/' + dataset_id
+    bbox_dir = 'data/imagenet/bb/'
+    images_dir = 'data/imagenet/images/'
     xml_files_by_dir = (i[2] for i in os.walk(bbox_dir))
     bbox_xml_files = itertools.chain(*xml_files_by_dir)
     imgs_with_bbox_xml = set([f.replace('.xml', '') for f in bbox_xml_files])

--- a/motion_tracker/data_setup/filter_imagenet_bb.py
+++ b/motion_tracker/data_setup/filter_imagenet_bb.py
@@ -9,7 +9,7 @@ import sys
 import os
 import pandas as pd
 
-def parse_imagenet_bb(raw_image_dir, parsed_bb_path):
+def parse_imagenet_bb(raw_image_dir, in_bb_path, out_bb_path):
     '''Return df with data about images and bounding boxes.
 
     Data captured corresponds to xml files obtained from ImageNet.
@@ -20,7 +20,7 @@ def parse_imagenet_bb(raw_image_dir, parsed_bb_path):
     max_box_frac_of_width =  0.66
     max_box_frac_of_height = 0.66
     images_successfully_downloaded = set(os.listdir(raw_image_dir))
-    bbox_df = (pd.read_csv(parsed_bb_path)
+    bbox_df = (pd.read_csv(in_bb_path)
                     .assign(box_height = lambda df: df.y1 - df.y0,
                             box_width = lambda df: df.x1 - df.x0)
                     .assign(box_frac_of_height = lambda df: 
@@ -33,11 +33,11 @@ def parse_imagenet_bb(raw_image_dir, parsed_bb_path):
 
     # Assuming the path ends in .csv, just insert a 2 in front 
     # of the .csv extension. 
-    out_filepath = parsed_bb_path[:-4] + '2' + '.csv'
-    bbox_df.to_csv(out_filepath, index=False)
+    bbox_df.to_csv(out_bb_path, index=False)
 
 if __name__ == '__main__': 
     raw_image_dir = sys.argv[1]
-    parsed_bb_path = sys.argv[2]
+    in_bb_path = sys.argv[2]
+    out_bb_path = sys.argv[3]
 
-    parse_imagenet_bb(raw_image_dir, parsed_bb_path)
+    parse_imagenet_bb(raw_image_dir, in_bb_path, out_bb_path)


### PR DESCRIPTION
@dansbecker Although I can't fire up a GPU instance quite yet and get the CUDA stuff all set, this is done and finished running end to end this morning. (Potentially) notable changes: 
1. I got rid of the separate `training` and `validation` imagenet make lines. We had earlier decided to put all the downloaded bounding box xmls into one folder (instead of separating them into `training` and `validation), so this is just a natural extension of that. Since we also can't download`validation` images, I think this probably doesn't matter too much. 
2. I added the `imagenet_images` dependency to the `make data`, so that running that will do everything from end to end and that's all you have to type in. 
3. I went ahead and changed the `parse_imagenet_bb2.py` name and made any other necessary changes that came along with that. 
