### PR TITLE
[WIP] Fix resize error

### DIFF
--- a/motion_tracker/utils/image_cropping.py
+++ b/motion_tracker/utils/image_cropping.py
@@ -123,6 +123,7 @@ def get_random_box_to_determine_crop(box_coords):
     # constructor, we calculate them explicitly here to find the edges
     # (i.e. to create new box Coords)
     x_shift_frac, y_shift_frac, x_size_change_frac, y_size_change_frac = get_cropping_params()
+
     box_for_crop_x_center = box_coords.x_center + x_shift_frac * box_coords.width
     box_for_crop_y_center = box_coords.y_center + y_shift_frac * box_coords.height
     box_for_crop_width = box_coords.width * x_size_change_frac
@@ -169,7 +170,6 @@ def get_crop_coords(box_coords, img_coords, random_crop):
     cropped_area_coords = Coords(cropped_area_x0, cropped_area_y0,
                                  cropped_area_x1, cropped_area_y1)
 
-
     box_after_crop = update_box_after_crop(box_coords, cropped_area_coords)
     return cropped_area_coords, box_after_crop
 
@@ -187,9 +187,13 @@ def crop_and_resize(img, img_coords, box_coords, output_width, output_height, ra
                  If False, create crop based on true bounding box
                  Cropped area is twice as large (and centered) on box either way
     '''
-    crop_coords, box_after_crop = get_crop_coords(box_coords, img_coords, random_crop)
-    cropped_img = img[crop_coords.y0:crop_coords.y1,
-                      crop_coords.x0:crop_coords.x1]
+
+    # Placeholder to get into the while loop the first time. 
+    cropped_img = np.zeros((2, 2))
+    while 0 not in cropped_img.shape: 
+        crop_coords, box_after_crop = get_crop_coords(box_coords, img_coords, random_crop)
+        cropped_img = img[crop_coords.y0:crop_coords.y1,
+                          crop_coords.x0:crop_coords.x1]
     box_after_crop = update_box_after_crop(box_coords, crop_coords)
     final_img = cv2.resize(cropped_img, (output_width, output_height))
     final_box_coords = update_box_after_resize(box_after_crop, crop_coords,


### PR DESCRIPTION
@dansbecker I at least figured out what the issue is. Basically, in some of the random croppings, laplace distribution parameters end up giving us a random bounding box who's center is outside of the original image dimensions. This ends up leading to issues in terms of x0 being greater than x1, or similar issues for y0 and y1. 

I've done my best to comment out the print statements that aren't currently relevant, and only include those that might demonstrate the problem. To that end, you should be able to run the generator from the main folder... `python motion_tracker/utils/image_generator.py`, at which point it will continue to run until a resizing error occurs. At that point, there'll be something like the output below: 

```
--------------------------------------------------
(306, 500, 3) # Original Image size 
0.10169054980587121 1.827571594469031 1.02451916969 0.948835020232 # laplace param results
Box for crop center x: 465.5 
Box for crop center y: 507.0
Box_after_crop: 24, 0, 77, -60
```

I've commented the first two lines - original image size and the laplace param results. Then, after words I've shown the x/y centers for the randomly cropped box. As you can see, both centers are larger than the original image size (although this isn't always the case - sometimes when it breaks it's just one). 

I think the easy solution here is to put some kind of test in here that makes sure the centers are not greater than the image size, and the redoes a random cropping if that happens. So, basically some kind of `while` loop. Now, this assumes that this is the only error causing this (which, when I ran this 5-10 times, was the only thing I could see causing this). 

So, I'll plan on doing that Friday I think. I've got a plane flight that I could use some work to do. 
